### PR TITLE
Modify document bugs

### DIFF
--- a/en/docs/tips/spack.md
+++ b/en/docs/tips/spack.md
@@ -52,6 +52,27 @@ You can confirm the registration completion if you see the following output when
 gcc@7.4.0  gcc@4.8.5  gcc@4.4.7
 ```
 
+Edit the compiler configuration file `$HOME/.spack/linux/compilers.yaml` to set rpath for GCC 7.4.0.
+
+```
+(snip)
+- compiler:
+    paths:
+      cc: /apps/gcc/7.4.0/bin/gcc
+      cxx: /apps/gcc/7.4.0/bin/g++
+      f77: /apps/gcc/7.4.0/bin/gfortran
+      fc: /apps/gcc/7.4.0/bin/gfortran
+    operating_system: centos7
+    target: x86_64
+    modules: []
+    environment: {}
+    extra_rpaths:                <- Edit here
+      - /apps/gcc/7.4.0/lib64    <- Add this line
+    flags: {}
+    spec: gcc@7.4.0
+(snip)
+```
+
 The default compiler can be specified in the configuration file `$HOME/.spack/linux/packages.yaml`.
 Add the following lines to the file to specify GCC 4.8.5 as the default compiler.
 ```
@@ -138,18 +159,18 @@ gcc@4.8.5:
 The default version of OpenMPI can be installed as follows.
 Refer to [Example Software Installation](#example_openmpi) for options.
 ```
-[username@es1 ~]$ spack install openmpi schedulers=sge
+[username@es1 ~]$ spack install openmpi schedulers=sge fabrics=auto
 ```
 
 If you want to install a specific version, use `@` to specify the version.
 ```
-[username@es1 ~]$ spack install openmpi@3.1.4 schedulers=sge
+[username@es1 ~]$ spack install openmpi@3.1.4 schedulers=sge fabrics=auto
 ```
 
 The compiler to build the software can be specified by `%`.
-The following example use GCC 7.3.0 for building OpenMPI.
+The following example use GCC 7.4.0 for building OpenMPI.
 ```
-[username@es1 ~]$ spack install openmpi@3.1.4 %gcc@7.3.0 schedulers=sge
+[username@es1 ~]$ spack install openmpi@3.1.4 %gcc@7.4.0 schedulers=sge fabrics=auto
 ```
 
 #### Uninstall {#uninstall}

--- a/en/docs/tips/spack.md
+++ b/en/docs/tips/spack.md
@@ -157,7 +157,7 @@ gcc@4.8.5:
 #### Install {#install}
 
 The default version of OpenMPI can be installed as follows.
-Refer to [Example Software Installation](#example_openmpi) for options.
+Refer to [Example Software Installation](#cuda-aware-openmpi) for options.
 ```
 [username@es1 ~]$ spack install openmpi schedulers=sge fabrics=auto
 ```
@@ -183,7 +183,7 @@ As with installation, you can uninstall software by specifying a version.
 
 Each software package installed by Spack has a hash, and you can also uninstall a software by specifying a hash.
 Specify `/` followed by a hash.
-You can get a hash of an installed software by `find` sub-command shown in [Information](#usage_package_info).
+You can get a hash of an installed software by `find` sub-command shown in [Information](#information).
 ```
 [username@es1 ~]$ spack uninstall /ffwtsvk
 ```
@@ -404,7 +404,7 @@ MVAPICH2 modules provided by ABCI does not support CUDA.
 If you want to use CUDA-aware MVAPICH2, install by yourself referring to the documents below.
 
 You have to use a compute node to build CUDA-aware MVAPICH2.
-As with [OpenMPI](#example_openmpi) above, you first install CUDA and then install MVAPICH2 by enabling CUDA (`+cuda`) and specifying a communication library (`fabrics=mrail`) and CUDA dependency (`^cuda@abci-10.1.243`).
+As with [OpenMPI](#cuda-aware-openmpi) above, you first install CUDA and then install MVAPICH2 by enabling CUDA (`+cuda`) and specifying a communication library (`fabrics=mrail`) and CUDA dependency (`^cuda@abci-10.1.243`).
 ```
 [username@g0001 ~]$ spack install cuda@abci-10.1.243
 [username@g0001 ~]$ spack install mvapich2@2.3 +cuda fabrics=mrail ^cuda@abci-10.1.243

--- a/ja/docs/tips/spack.md
+++ b/ja/docs/tips/spack.md
@@ -56,6 +56,27 @@ Spackに登録されているコンパイラを表示するコマンド`spack co
 gcc@7.4.0  gcc@4.8.5  gcc@4.4.7
 ```
 
+コンパイラの設定ファイル`$HOME/.spack/linux/compilers.yaml`を編集し、GCC 7.4.0のrpathを設定します。
+
+```
+(snip)
+- compiler:
+    paths:
+      cc: /apps/gcc/7.4.0/bin/gcc
+      cxx: /apps/gcc/7.4.0/bin/g++
+      f77: /apps/gcc/7.4.0/bin/gfortran
+      fc: /apps/gcc/7.4.0/bin/gfortran
+    operating_system: centos7
+    target: x86_64
+    modules: []
+    environment: {}
+    extra_rpaths:                <- ここを編集
+      - /apps/gcc/7.4.0/lib64    <- この行を追加
+    flags: {}
+    spec: gcc@7.4.0
+(snip)
+```
+
 標準で使用するコンパイラは設定ファイル`$HOME/.spack/linux/packages.yaml`で設定できます。
 以下の例では標準コンパイラをgcc 4.8.5に設定しています。
 
@@ -142,20 +163,20 @@ gcc@4.8.5:
 #### インストール {#install}
 
 OpenMPIのSpack標準バージョンは、以下の通りにインストールできます。
-`schedulers=sge`の意味は[導入事例](#example_openmpi)を参照ください。
+`schedulers=sge`と`fabrics=auto`の意味は[導入事例](#example_openmpi)を参照ください。
 ```
-[username@es1 ~]$ spack install openmpi schedulers=sge
+[username@es1 ~]$ spack install openmpi schedulers=sge fabrics=auto
 ```
 
 バージョンを指定する場合は、`@`で指定します。
 ```
-[username@es1 ~]$ spack install openmpi@3.1.4 schedulers=sge
+[username@es1 ~]$ spack install openmpi@3.1.4 schedulers=sge fabrics=auto
 ```
 
 コンパイラを指定する場合は`%`で指定します。
 以下の例では、コンパイラのバージョンも指定しています。
 ```
-[username@es1 ~]$ spack install openmpi@3.1.4 %gcc@7.3.0 schedulers=sge
+[username@es1 ~]$ spack install openmpi@3.1.4 %gcc@7.4.0 schedulers=sge fabrics=auto
 ```
 
 #### アンインストール {#uninstall}

--- a/ja/docs/tips/spack.md
+++ b/ja/docs/tips/spack.md
@@ -163,7 +163,7 @@ gcc@4.8.5:
 #### インストール {#install}
 
 OpenMPIのSpack標準バージョンは、以下の通りにインストールできます。
-`schedulers=sge`と`fabrics=auto`の意味は[導入事例](#example_openmpi)を参照ください。
+`schedulers=sge`と`fabrics=auto`の意味は[導入事例](#cuda-aware-openmpi)を参照ください。
 ```
 [username@es1 ~]$ spack install openmpi schedulers=sge fabrics=auto
 ```
@@ -189,7 +189,7 @@ OpenMPIのSpack標準バージョンは、以下の通りにインストール�
 
 ソフトウェアのハッシュを指定してアンインストールすることもできます。
 `/`に続いてハッシュを指定します。
-ハッシュは[情報確認](#usage_package_info)に示す通り、`find`サブコマンドで取得できます。
+ハッシュは[情報確認](#information)に示す通り、`find`サブコマンドで取得できます。
 ```
 [username@es1 ~]$ spack uninstall /ffwtsvk
 ```
@@ -409,7 +409,7 @@ ABCIが提供するMVAPICH2モジュールはCUDA対応していません。
 CUDA-aware MVAPICH2を使用する場合は、以下を参考にSpackでインストールしてください。
 
 GPUを搭載する計算ノード上で作業を行います。
-[OpenMPIと同様](#example_openmpi)に、使用するCUDAをインストールしたのちに、CUDAオプション（`+cuda`）、通信ライブラリ（`fabrics=mrail`）、およびCUDAの依存関係（`^cuda@abci-10.1.243`）を指定してMVAPICH2をインストールします。
+[OpenMPIと同様](#cuda-aware-openmpi)に、使用するCUDAをインストールしたのちに、CUDAオプション（`+cuda`）、通信ライブラリ（`fabrics=mrail`）、およびCUDAの依存関係（`^cuda@abci-10.1.243`）を指定してMVAPICH2をインストールします。
 ```
 [username@g0001 ~]$ spack install cuda@abci-10.1.243
 [username@g0001 ~]$ spack install mvapich2@2.3 +cuda fabrics=mrail ^cuda@abci-10.1.243


### PR DESCRIPTION
GCC 7.4.0を使う場合、コンパイラのextra_rpathにGCC 7.4.0のライブラリを設定しないと、一部のソフトウェア（発生したのはOpenMPI  3.1.3 compiled with GCC 7.4.0）で実行時エラーになることを確認しました。