### PR TITLE
fix Windows 10 ProxyCommand instruction

### DIFF
--- a/en/docs/02.md
+++ b/en/docs/02.md
@@ -73,7 +73,7 @@ Enter passphrase for key '/path/identity_file': <- Enter passphrase
 
 #### ProxyJump
 
-If you have OpenSSH 7.3 or later, you can directly connect to the interactive node.
+You can log in to an interactive node with a single command using ProxyJump, which was introduced in OpenSSH version 7.3. It can also be used in a Windows Subsystem for Linux (WSL) environment.
 
 First, add the following configuration to your ``$HOME/.ssh/config``:
 
@@ -94,8 +94,18 @@ After that, you can log in with the following command only:
 [yourpc ~]$ ssh <i>abci</i>
 </pre></div>
 
-!!! warning
-    OpenSSH_for_Windows_7.7p1, bundled with Windows 10 version 1803 or later, does not allow you to use ProxyJump and ProxyCommand. They can be used in OpenSSH clients bundled with Windows Subsystem for Linux (WSL).
+ProxyJump does not work with OpenSSH_for_Windows_7.7p1 included in Windows 10 since version 1803. Use ProxyCommand instead. The following is an example of a config file using ProxyCommand. `ssh.exe` must be specified with an absolute path.
+
+<div class="codehilite"><pre>
+Host <i>abci</i>
+     HostName <i>es</i>
+     User username
+     ProxyCommand C:\WINDOWS\System32\OpenSSH\ssh.exe -W %h:%p %r@<i>as.abci.ai</i>
+     IdentityFile C:\path\to\identity_file
+
+Host <i>as.abci.ai</i>
+     IdentityFile C:\path\to\identity_file
+</pre></div>
 
 ## 2.3. File Transfer to Interactive Node {#file-transfer-to-interactive-node}
 

--- a/en/docs/02.md
+++ b/en/docs/02.md
@@ -73,7 +73,7 @@ Enter passphrase for key '/path/identity_file': <- Enter passphrase
 
 #### ProxyJump
 
-You can log in to an interactive node with a single command using ProxyJump, which was introduced in OpenSSH version 7.3. It can also be used in a Windows Subsystem for Linux (WSL) environment.
+You can log in to an interactive node with a single command using ProxyJump, which was introduced in OpenSSH version 7.3. ProxyJump can be used in Windows Subsystem for Linux (WSL) environment as well.
 
 First, add the following configuration to your ``$HOME/.ssh/config``:
 
@@ -94,7 +94,7 @@ After that, you can log in with the following command only:
 [yourpc ~]$ ssh <i>abci</i>
 </pre></div>
 
-ProxyJump does not work with OpenSSH_for_Windows_7.7p1 included in Windows 10 since version 1803. Use ProxyCommand instead. The following is an example of a config file using ProxyCommand. `ssh.exe` must be specified with an absolute path.
+ProxyJump does not work with OpenSSH_for_Windows_7.7p1 which is bundled with Windows 10 version 1803 and later. Use ProxyCommand instead. The following is an example of a config file using ProxyCommand. Please specify the absolute path for `ssh.exe`.
 
 <div class="codehilite"><pre>
 Host <i>abci</i>

--- a/ja/docs/02.md
+++ b/ja/docs/02.md
@@ -97,7 +97,18 @@ Host <i>as.abci.ai</i>
 </pre></div>
 
 !!! warning
-    Windows 10 バージョン1803以降に標準でバンドルされているOpenSSH_for_Windows_7.7p1では、ProxyJumpおよびProxyCommandが使えません。Windows Subsystem for Linux (WSL)にバンドルされているOpenSSHでは使えます。
+    Windows 10 バージョン1803以降に標準でバンドルされているOpenSSH_for_Windows_7.7p1では、ProxyJumpが使えません。その代わりにProxyCommandを使用してください。Windows Subsystem for Linux (WSL)にバンドルされているOpenSSHでは使えます。
+
+Windows 10 バージョン1803以降に標準でバンドルされているOpenSSH_for_Windows_7.7p1でProxyCommandを使用する際には、以下の例に示すように、.ssh/configではssh.exeを絶対パスで記述して下さい。
+
+<div class="codehilite"><pre>
+Host <i>abci</i>
+     HostName <i>es</i>
+     User username
+     ProxyJump %r@<i>as.abci.ai</i>
+     ProxyCommand C:\WINDOWS\System32\OpenSSH\ssh.exe -l username -W %h:%p <i>as.abci.ai</i>
+     IdentityFile /path/identity_file
+</pre></div>
 
 ## 2.3. インタラクティブノードへのファイル転送 {#file-transfer-to-interactive-node}
 

--- a/ja/docs/02.md
+++ b/ja/docs/02.md
@@ -75,7 +75,7 @@ Enter passphrase for key '-i /path/identity_file': <- パスフレーズ入力
 
 #### ProxyJumpの使用 {#proxyjump}
 
-ここではOpenSSH 7.3以降で実装されたProxyJumpを使ったログイン方法を説明します。
+ここではOpenSSH 7.3で実装されたProxyJumpを使ったログイン方法を説明します。Windows Subsystem for Linux (WSL)でも同様のログイン方法が使えます。
 
 まずローカルPCの``$HOME/.ssh/config``に以下の記述を行います。
 
@@ -96,7 +96,7 @@ Host <i>as.abci.ai</i>
 [yourpc ~]$ ssh <i>abci</i>
 </pre></div>
 
-Windows 10 バージョン 1803 以降に標準でバンドルされている OpenSSH_for_Windows_7.7p1 では ProxyJump が機能しないため、代わりに ProxyCommand を使用してください。Windows Subsystem for Linux (WSL) をお使いの場合は、前述の ProxyJump を使う設定を参考にしてください。以下に ProxyCommand を使った config ファイルの例を示します。ssh.exe は絶対パスで記述して下さい。
+Windows 10 バージョン 1803 以降に標準でバンドルされている OpenSSH_for_Windows_7.7p1 では ProxyJump が機能しないため、代わりに ProxyCommand を使用してください。以下に ProxyCommand を使った config ファイルの例を示します。ssh.exe は絶対パスで記述して下さい。
 
 <div class="codehilite"><pre>
 Host <i>abci</i>

--- a/ja/docs/02.md
+++ b/ja/docs/02.md
@@ -84,10 +84,10 @@ Host <i>abci</i>
      HostName <i>es</i>
      User username
      ProxyJump %r@<i>as.abci.ai</i>
-     IdentityFile /path/identity_file
+     IdentityFile /path/to/identity_file
 
 Host <i>as.abci.ai</i>
-     IdentityFile /path/identity_file
+     IdentityFile /path/to/identity_file
 </pre></div>
 
 以降は、以下のコマンドのみでログインできます。
@@ -96,18 +96,17 @@ Host <i>as.abci.ai</i>
 [yourpc ~]$ ssh <i>abci</i>
 </pre></div>
 
-!!! warning
-    Windows 10 バージョン1803以降に標準でバンドルされているOpenSSH_for_Windows_7.7p1では、ProxyJumpが使えません。その代わりにProxyCommandを使用してください。Windows Subsystem for Linux (WSL)にバンドルされているOpenSSHでは使えます。
-
-Windows 10 バージョン1803以降に標準でバンドルされているOpenSSH_for_Windows_7.7p1でProxyCommandを使用する際には、以下の例に示すように、.ssh/configではssh.exeを絶対パスで記述して下さい。
+Windows 10 バージョン 1803 以降に標準でバンドルされている OpenSSH_for_Windows_7.7p1 では ProxyJump が機能しませんので、代わりに ProxyCommand を使用してください。Windows Subsystem for Linux (WSL) をお使いの場合は、前述の ProxyJump を使う設定を参考にしてください。以下に ProxyCommand を使った config ファイルの例を示します。ssh.exe は絶対パスで記述して下さい。
 
 <div class="codehilite"><pre>
 Host <i>abci</i>
      HostName <i>es</i>
      User username
-     ProxyJump %r@<i>as.abci.ai</i>
-     ProxyCommand C:\WINDOWS\System32\OpenSSH\ssh.exe -l username -W %h:%p <i>as.abci.ai</i>
-     IdentityFile /path/identity_file
+     ProxyCommand C:\WINDOWS\System32\OpenSSH\ssh.exe -W %h:%p %r@<i>as.abci.ai</i>
+     IdentityFile C:\path\to\identity_file
+
+Host <i>as.abci.ai</i>
+     IdentityFile C:\path\to\identity_file
 </pre></div>
 
 ## 2.3. インタラクティブノードへのファイル転送 {#file-transfer-to-interactive-node}

--- a/ja/docs/02.md
+++ b/ja/docs/02.md
@@ -96,7 +96,7 @@ Host <i>as.abci.ai</i>
 [yourpc ~]$ ssh <i>abci</i>
 </pre></div>
 
-Windows 10 バージョン 1803 以降に標準でバンドルされている OpenSSH_for_Windows_7.7p1 では ProxyJump が機能しませんので、代わりに ProxyCommand を使用してください。Windows Subsystem for Linux (WSL) をお使いの場合は、前述の ProxyJump を使う設定を参考にしてください。以下に ProxyCommand を使った config ファイルの例を示します。ssh.exe は絶対パスで記述して下さい。
+Windows 10 バージョン 1803 以降に標準でバンドルされている OpenSSH_for_Windows_7.7p1 では ProxyJump が機能しないため、代わりに ProxyCommand を使用してください。Windows Subsystem for Linux (WSL) をお使いの場合は、前述の ProxyJump を使う設定を参考にしてください。以下に ProxyCommand を使った config ファイルの例を示します。ssh.exe は絶対パスで記述して下さい。
 
 <div class="codehilite"><pre>
 Host <i>abci</i>


### PR DESCRIPTION
Windows 10 の吊るしのsshでProxCommandを使用する方法を追記しました。