### PR TITLE
Add missing lines for Spack

### DIFF
--- a/en/docs/index.md
+++ b/en/docs/index.md
@@ -28,6 +28,7 @@ All users who use this system are strongly recommended to read this document, as
     - [PuTTY](tips/putty.md)
     - [Jupyter Notebook](tips/jupyter-notebook.md)
     - [Singularity Global Client](tips/sregistry-cli.md)
+    - [Spack](tips/spack.md)
   - [NVIDIA GPU Cloud (NGC)](ngc.md)
   - ABCI Cloud Storage:
     - [Overview](abci-cloudstorage.md)

--- a/ja/docs/index.md
+++ b/ja/docs/index.md
@@ -28,6 +28,7 @@
     - [PuTTYの利用](tips/putty.md)
     - [Jupyter Notebookの利用](tips/jupyter-notebook.md)
     - [Singularity Global Clientの利用](tips/sregistry-cli.md)
+    - [Spackによるソフトウェア管理](tips/spack.md)
   - [NVIDIA GPU Cloud (NGC)](ngc.md)
   - ABCI クラウドストレージ:
     - [概要](abci-cloudstorage.md)


### PR DESCRIPTION
index.md の方に spack のエントリがないのに気がつきましたので、追加です。
mkdocs.yml の方にはエントリがあります。