### PR TITLE
Fj20200729 01

### DIFF
--- a/en/docs/09.md
+++ b/en/docs/09.md
@@ -16,9 +16,8 @@ To use Singularity, set up user environment by the `module` command.
 ```
 
 More comprehensive user guide for Singularity will be found:  
-
 [Singularity 2.6 User Guide](https://www.sylabs.io/guides/2.6/user-guide/)  
-[Singularity PRO 3.5 User Guide](https://repo.sylabs.io/c/0f6898986ad0b646b5ce6deba21781ac62cb7e0a86a5153bbb31732ee6593f43/guides/singularitypro35-user-guide)  
+[Singularity PRO 3.5 User Guide](https://repo.sylabs.io/c/0f6898986ad0b646b5ce6deba21781ac62cb7e0a86a5153bbb31732ee6593f43/guides/singularitypro35-user-guide/)  
 
 To run NGC-provided Docker images on ABCI by using Singularity: [NVIDIA GPU Cloud (NGC)](ngc.md)
 

--- a/en/docs/09.md
+++ b/en/docs/09.md
@@ -17,7 +17,7 @@ To use Singularity, set up user environment by the `module` command.
 
 More comprehensive user guide for Singularity will be found:  
 [User Guide &mdash; Singularity container 2.6 documentation](https://www.sylabs.io/guides/2.6/user-guide/)  
-[User Guide &mdash; Singularity container 3.5 documentation](https://www.sylabs.io/guides/3.5/user-guide/)
+[User Guide &mdash; Singularity PRO Users Guide 3.5](https://repo.sylabs.io/c/0f6898986ad0b646b5ce6deba21781ac62cb7e0a86a5153bbb31732ee6593f43/guides/singularitypro35-user-guide/index.html)
 
 To run NGC-provided Docker images on ABCI by using Singularity: [NVIDIA GPU Cloud (NGC)](ngc.md)
 

--- a/en/docs/09.md
+++ b/en/docs/09.md
@@ -16,8 +16,9 @@ To use Singularity, set up user environment by the `module` command.
 ```
 
 More comprehensive user guide for Singularity will be found:  
-[User Guide &mdash; Singularity container 2.6 documentation](https://www.sylabs.io/guides/2.6/user-guide/)  
-[User Guide &mdash; Singularity PRO Users Guide 3.5](https://repo.sylabs.io/c/0f6898986ad0b646b5ce6deba21781ac62cb7e0a86a5153bbb31732ee6593f43/guides/singularitypro35-user-guide/index.html)
+
+[Singularity 2.6 User Guide](https://www.sylabs.io/guides/2.6/user-guide/)  
+[Singularity PRO 3.5 User Guide](https://repo.sylabs.io/c/0f6898986ad0b646b5ce6deba21781ac62cb7e0a86a5153bbb31732ee6593f43/guides/singularitypro35-user-guide)  
 
 To run NGC-provided Docker images on ABCI by using Singularity: [NVIDIA GPU Cloud (NGC)](ngc.md)
 

--- a/en/docs/faq.md
+++ b/en/docs/faq.md
@@ -28,14 +28,14 @@ Singularity version 2.6 and Singularity PRO version 3.5 have a function equivale
 
 For more information on Singularity version 2.6 authentication, see below.
 
-* [Singularity Container Documentation](https://www.sylabs.io/guides/2.6/user-guide.pdf)
-    * 14.6 How do I specify my Docker image?
-    * 14.7 Custom Authentication
+* [Singularity 2.6 User Guide](https://www.sylabs.io/guides/2.6/user-guide/)
+    * [How do I specify my Docker image?](https://sylabs.io/guides/2.6/user-guide/singularity_and_docker.html#how-do-i-specify-my-docker-image)
+    * [Custom Authentication](https://sylabs.io/guides/2.6/user-guide/singularity_and_docker.html#custom-authentication)  
 
 For more information on Singularity PRO version 3.5 authentication, see below.
 
-* [User Guide &mdash; Singularity PRO Users Guide 3.5](https://repo.sylabs.io/c/0f6898986ad0b646b5ce6deba21781ac62cb7e0a86a5153bbb31732ee6593f43/guides/singularitypro35-user-guide.pdf) 
-    * 2.4 Support for Docker and OCI
+* [Singularity PRO 3.5 User Guide](https://repo.sylabs.io/c/0f6898986ad0b646b5ce6deba21781ac62cb7e0a86a5153bbb31732ee6593f43/guides/singularitypro35-user-guide)  
+    * [Making use of private images from Private Registries](https://repo.sylabs.io/c/0f6898986ad0b646b5ce6deba21781ac62cb7e0a86a5153bbb31732ee6593f43/guides/singularitypro35-user-guide/singularity_and_docker.html?highlight=support%20docker%20oci#making-use-of-private-images-from-private-registries) 
 
 ## Q. NGC CLI cannot be executed
 

--- a/en/docs/faq.md
+++ b/en/docs/faq.md
@@ -34,7 +34,7 @@ For more information on Singularity version 2.6 authentication, see below.
 
 For more information on Singularity PRO version 3.5 authentication, see below.
 
-* [Singularity PRO 3.5 User Guide](https://repo.sylabs.io/c/0f6898986ad0b646b5ce6deba21781ac62cb7e0a86a5153bbb31732ee6593f43/guides/singularitypro35-user-guide)  
+* [Singularity PRO 3.5 User Guide](https://repo.sylabs.io/c/0f6898986ad0b646b5ce6deba21781ac62cb7e0a86a5153bbb31732ee6593f43/guides/singularitypro35-user-guide/)  
     * [Making use of private images from Private Registries](https://repo.sylabs.io/c/0f6898986ad0b646b5ce6deba21781ac62cb7e0a86a5153bbb31732ee6593f43/guides/singularitypro35-user-guide/singularity_and_docker.html?highlight=support%20docker%20oci#making-use-of-private-images-from-private-registries) 
 
 ## Q. NGC CLI cannot be executed

--- a/en/docs/faq.md
+++ b/en/docs/faq.md
@@ -34,7 +34,7 @@ For more information on Singularity version 2.6 authentication, see below.
 
 For more information on Singularity PRO version 3.5 authentication, see below.
 
-* [Singularity Container Documentation](https://www.sylabs.io/guides/3.5/user-guide.pdf)
+* [User Guide &mdash; Singularity PRO Users Guide 3.5](https://repo.sylabs.io/c/0f6898986ad0b646b5ce6deba21781ac62cb7e0a86a5153bbb31732ee6593f43/guides/singularitypro35-user-guide.pdf) 
     * 2.4 Support for Docker and OCI
 
 ## Q. NGC CLI cannot be executed

--- a/ja/docs/09.md
+++ b/ja/docs/09.md
@@ -17,7 +17,7 @@ ABCIシステムでは[Singularity](https://www.sylabs.io/singularity/)が利用
 
 より網羅的なユーザガイドは、以下にあります。  
 [Singularity 2.6 User Guide](https://www.sylabs.io/guides/2.6/user-guide/)  
-[Singularity PRO 3.5 User Guide](https://repo.sylabs.io/c/0f6898986ad0b646b5ce6deba21781ac62cb7e0a86a5153bbb31732ee6593f43/guides/singularitypro35-user-guide) 
+[Singularity PRO 3.5 User Guide](https://repo.sylabs.io/c/0f6898986ad0b646b5ce6deba21781ac62cb7e0a86a5153bbb31732ee6593f43/guides/singularitypro35-user-guide/) 
 
 Singularityを用いて、NGCが提供するDockerイメージをABCIで実行する方法は、[NVIDIA GPU Cloud (NGC)](ngc.md) で説明しています。
 

--- a/ja/docs/09.md
+++ b/ja/docs/09.md
@@ -16,9 +16,8 @@ ABCIシステムでは[Singularity](https://www.sylabs.io/singularity/)が利用
 ```
 
 より網羅的なユーザガイドは、以下にあります。  
-[User Guide &mdash; Singularity container 2.6 documentation](https://www.sylabs.io/guides/2.6/user-guide/)   
-[User Guide &mdash; Singularity PRO Users Guide 3.5](https://repo.sylabs.io/c/0f6898986ad0b646b5ce6deba21781ac62cb7e0a86a5153bbb31732ee6593f43/guides/singularitypro35-user-guide/index.html)  
-
+[Singularity 2.6 User Guide](https://www.sylabs.io/guides/2.6/user-guide/)  
+[Singularity PRO 3.5 User Guide](https://repo.sylabs.io/c/0f6898986ad0b646b5ce6deba21781ac62cb7e0a86a5153bbb31732ee6593f43/guides/singularitypro35-user-guide) 
 
 Singularityを用いて、NGCが提供するDockerイメージをABCIで実行する方法は、[NVIDIA GPU Cloud (NGC)](ngc.md) で説明しています。
 

--- a/ja/docs/09.md
+++ b/ja/docs/09.md
@@ -17,7 +17,8 @@ ABCIシステムでは[Singularity](https://www.sylabs.io/singularity/)が利用
 
 より網羅的なユーザガイドは、以下にあります。  
 [User Guide &mdash; Singularity container 2.6 documentation](https://www.sylabs.io/guides/2.6/user-guide/)   
-[User Guide &mdash; Singularity container 3.5 documentation](https://www.sylabs.io/guides/3.5/user-guide/) 
+[User Guide &mdash; Singularity PRO Users Guide 3.5](https://repo.sylabs.io/c/0f6898986ad0b646b5ce6deba21781ac62cb7e0a86a5153bbb31732ee6593f43/guides/singularitypro35-user-guide/index.html)  
+
 
 Singularityを用いて、NGCが提供するDockerイメージをABCIで実行する方法は、[NVIDIA GPU Cloud (NGC)](ngc.md) で説明しています。
 

--- a/ja/docs/faq.md
+++ b/ja/docs/faq.md
@@ -34,7 +34,7 @@ Singularity version 2.6の認証に関する詳細は、以下をご参照くだ
 
 Singularity PRO version 3.5の認証に関する詳細は、以下をご参照ください。
 
-* [Singularity PRO 3.5 User Guide](https://repo.sylabs.io/c/0f6898986ad0b646b5ce6deba21781ac62cb7e0a86a5153bbb31732ee6593f43/guides/singularitypro35-user-guide)
+* [Singularity PRO 3.5 User Guide](https://repo.sylabs.io/c/0f6898986ad0b646b5ce6deba21781ac62cb7e0a86a5153bbb31732ee6593f43/guides/singularitypro35-user-guide/)
     * [Making use of private images from Private Registries](https://repo.sylabs.io/c/0f6898986ad0b646b5ce6deba21781ac62cb7e0a86a5153bbb31732ee6593f43/guides/singularitypro35-user-guide/singularity_and_docker.html?highlight=support%20docker%20oci#making-use-of-private-images-from-private-registries)
 
 ## Q. NGC CLIが実行できない

--- a/ja/docs/faq.md
+++ b/ja/docs/faq.md
@@ -28,14 +28,14 @@ Singularity version 2.6およびSingularity PRO version 3.5には``docker login`
 
 Singularity version 2.6の認証に関する詳細は、以下をご参照ください。
 
-* [Singularity Container Documentation](https://www.sylabs.io/guides/2.6/user-guide.pdf)
-    * 14.6 How do I specify my Docker image?
-    * 14.7 Custom Authentication
+* [Singularity 2.6 User Guide](https://www.sylabs.io/guides/2.6/user-guide/)  
+    * [How do I specify my Docker image?](https://sylabs.io/guides/2.6/user-guide/singularity_and_docker.html#how-do-i-specify-my-docker-image)
+    * [Custom Authentication](https://sylabs.io/guides/2.6/user-guide/singularity_and_docker.html#custom-authentication)
 
 Singularity PRO version 3.5の認証に関する詳細は、以下をご参照ください。
 
-* [User Guide &mdash; Singularity PRO Users Guide 3.5](https://repo.sylabs.io/c/0f6898986ad0b646b5ce6deba21781ac62cb7e0a86a5153bbb31732ee6593f43/guides/singularitypro35-user-guide.pdf) 
-    * 2.4 Support for Docker and OCI
+* [Singularity PRO 3.5 User Guide](https://repo.sylabs.io/c/0f6898986ad0b646b5ce6deba21781ac62cb7e0a86a5153bbb31732ee6593f43/guides/singularitypro35-user-guide)
+    * [Making use of private images from Private Registries](https://repo.sylabs.io/c/0f6898986ad0b646b5ce6deba21781ac62cb7e0a86a5153bbb31732ee6593f43/guides/singularitypro35-user-guide/singularity_and_docker.html?highlight=support%20docker%20oci#making-use-of-private-images-from-private-registries)
 
 ## Q. NGC CLIが実行できない
 

--- a/ja/docs/faq.md
+++ b/ja/docs/faq.md
@@ -34,7 +34,7 @@ Singularity version 2.6の認証に関する詳細は、以下をご参照くだ
 
 Singularity PRO version 3.5の認証に関する詳細は、以下をご参照ください。
 
-* [Singularity Container Documentation](https://www.sylabs.io/guides/3.5/user-guide.pdf)
+* [User Guide &mdash; Singularity PRO Users Guide 3.5](https://repo.sylabs.io/c/0f6898986ad0b646b5ce6deba21781ac62cb7e0a86a5153bbb31732ee6593f43/guides/singularitypro35-user-guide.pdf) 
     * 2.4 Support for Docker and OCI
 
 ## Q. NGC CLIが実行できない


### PR DESCRIPTION
Singularity PRO 3.5 の User Guide公開について、Sylabs社より了承が得られたのでURLを修正しました。
（修正前はSingularity 3.5のUser Guide参照にしていました）
また、Singuklarity 2.6も、Singularity PRO 3.5 と書き方を統一するため修正しています。