### PR TITLE
Fix link to CS terms of use

### DIFF
--- a/en/docs/abci-cloudstorage/acl.md
+++ b/en/docs/abci-cloudstorage/acl.md
@@ -134,7 +134,7 @@ Two standard ACLs open buckets and objects to the public, which enable any inter
     Before you grant read access to everyone in the world, please read the following agreements carefully, and make sure it is appropriate to do so.
     
     * [ABCI agreement and rules](https://abci.ai/en/how_to_use/)
-    * [ABCI Cloud Storage Terms of Use](https://abci.ai/en/how_to_use/data/cloudstorage-agreement.pdf)
+    * [ABCI Cloud Storage Terms of Use](https://abci.ai/en/how_to_use/data/Cloudstorage-agreement-en.pdf)
 
 !!! caution
     Please do not use 'public-read-write' due to the possibility of unintended use by a third party.


### PR DESCRIPTION
改訂の時にファイル名が変更されたようで、
英語版のクラウドストレージ利用規約へのリンクが切れていました。
ポータルに埋まっているものは、当時の改修で修正されたようで、リンク切れになっていませんでした(たどれることを確認しました)。ポータルと関係のないド今回の部分だけ取り残されていたようです。
参照先のファイル名を直したい気もしますが、ポータル側の修正が必要になってしまいますので、
ドキュメント側を修正しました。