### PR TITLE
Update Scality S3 Connector version

### DIFF
--- a/en/docs/system-updates.md
+++ b/en/docs/system-updates.md
@@ -1,5 +1,11 @@
 # System Updates
 
+## 2020-08-31
+
+| Add / Update / Delete | Software | Version | Previous version |
+|:--|:--|:--|:--|
+| Update | Scality S3 Connector | 7.4.6.3 | 7.4.5.4 |
+
 ## 2020-07-31
 
 | Add / Update / Delete | Software | Version | Previous version |

--- a/ja/docs/system-updates.md
+++ b/ja/docs/system-updates.md
@@ -1,5 +1,11 @@
 # システム更新履歴
 
+## 2020-08-31
+
+| Add / Update / Delete | Software | Version | Previous version |
+|:--|:--|:--|:--|
+| Update | Scality S3 Connector | 7.4.6.3 | 7.4.5.4 |
+
 ## 2020-07-31
 
 | Add / Update / Delete | Software | Version | Previous version |


### PR DESCRIPTION
Scality S3 Connectorのアップデート (7.4.5.4 -> 7.4.6.3 ) を実施しましたので
利用手引きの「システム更新履歴」に追加しました。