### PR TITLE
計算ノードでsingularity build/pull実行時に容量不足でエラーになった場合の対処方法をFAQに追加

### DIFF
--- a/en/docs/faq.md
+++ b/en/docs/faq.md
@@ -168,6 +168,18 @@ Example)
 [username@g0001 ~]$ singularity run --nv docker://caffe2ai/caffe2:latest
 ```
 
+## Q. I get an error due to insufficient disk space, when I ran the singularity build/pull on the compute node. {#q-insufficient-disk-space-for-singularity-build}
+
+The `singularity build` and `pull` commands use `/tmp` as the location to create temporary files.
+When you build a large container on the compute node, it may cause an error due to insufficient space in `/tmp`.
+
+If you get an error due to insufficient space, set the `SINGULARITY_TMPDIR` environment variable to use the local storage as shown below:
+
+```
+[username@g0001 ~]$ SINGULARITY_TMPDIR=$SGE_LOCALDIR singularity pull docker://nvcr.io/nvidia/tensorflow:20.12-tf1-py3
+```
+
+
 ## Q. How can I find the job ID?
 
 When you submit a batch job using the `qsub` command, the command outputs the job ID.

--- a/ja/docs/faq.md
+++ b/ja/docs/faq.md
@@ -174,6 +174,17 @@ FATAL:   While making image from oci registry: while building SIF from layers: u
 [username@g0001 ~]$ singularity run --nv docker://caffe2ai/caffe2:latest
 ```
 
+## Q. 計算ノードでsingularity build/pullすると容量不足でエラーになる {#q-insufficient-disk-space-for-singularity-build}
+
+singularity build/pull コマンドは一時ファイルの作成場所として `/tmp` を使用します。
+大きなコンテナを計算ノード上でsingularity build/pullする際に `/tmp` の容量が足りずエラーになる場合があります。
+容量が足りずエラーになる場合は、次のようにローカルスクラッチを使用するよう`SINGULARITY_TMPDIR`環境変数を設定してください。
+
+```
+[username@g0001 ~]$ SINGULARITY_TMPDIR=$SGE_LOCALDIR singularity pull docker://nvcr.io/nvidia/tensorflow:20.12-tf1-py3
+```
+
+
 ## Q. ジョブ ID を調べるには？ {#q-how-can-i-find-the-job-id}
 
 `qsub` コマンドを使ってバッチジョブを投入した場合は、コマンドがジョブ ID を出力しています。


### PR DESCRIPTION
計算ノードの/tmpが足りず singularity build/pullがエラーになった場合の対処方法をFAQに追加しました。