### PR TITLE
Added some text about who can use the reservation ID.

### DIFF
--- a/en/docs/job-execution.md
+++ b/en/docs/job-execution.md
@@ -472,7 +472,8 @@ The maximum number of nodes and the node-time product that can be reserved for t
 
 ### Make a reservation
 
-To make a reservation compute node, use `qrsub` command or the ABCI User Portal .
+To make a reservation compute node, use `qrsub` command or the ABCI User Portal.
+When the reservation is completed, a reservation ID will be issued. Please specify this reservation ID when using the reserved node.
 
 !!! warning
     Making reservation of compute node is permitted to a responsible person or a manager.
@@ -501,14 +502,15 @@ Example) Make a reservation 4 compute nodes(V) from 2018/07/05 to 1 week (7 days
 Your advance reservation 12345 has been granted
 ```
 
-The ABCI points are consumed when complete reservation.
-
 Example) Make a reservation 4 compute nodes(A) from 2021/07/05 to 1 week (7 days)
 
 ```
 [username@es1 ~]$ qrsub -a 20210705 -d 7 -g grpname -n 4 -N "Reserve_for_AI" -l rt_AF
 Your advance reservation 12345 has been granted
 ```
+
+The ABCI points are consumed when complete reservation.
+In addition, the issued reservation ID can be used for the ABCI accounts belonging to the ABCI group specified at the time of reservation.
 
 ### Show the status of reservations
 

--- a/ja/docs/job-execution.md
+++ b/ja/docs/job-execution.md
@@ -480,6 +480,7 @@ Reservedサービスでは、計算ノードを事前に予約して計画的な
 ### 予約の実行 {#make-a-reservation}
 
 計算ノードを予約するには、[ABCI利用ポータル](https://portal.abci.ai/user/)もしくは`qrsub`コマンドを使用します。
+予約が完了すると、予約IDが発行されますので、予約した計算ノードを使用する際にこの予約IDを指定してください。
 
 !!! warning
     計算ノードの予約は、利用責任者もしくは利用管理者のみが実施できます。
@@ -516,6 +517,7 @@ Your advance reservation 12345 has been granted
 ```
 
 計算ノードの予約が完了した時点でABCIポイントを消費します。
+また、発行された予約IDは予約時に指定したABCIグループに所属するABCIアカウントでご利用いただけます。
 
 ### 予約状態の確認 {#show-the-status-of-reservations}
 


### PR DESCRIPTION
Reservedサービスにおいて、予約IDを使えるのが誰か記述がないため、予約を行える管理者しか予約ジョブを投げられないように見えます。
そこで、予約IDは「予約時に指定したABCIグループに所属するABCIアカウント」が使える文言を追加しました。