### PR TITLE
Correct old content

### DIFF
--- a/en/docs/development-tools.md
+++ b/en/docs/development-tools.md
@@ -24,7 +24,7 @@ If you set up with the `module` command in compute node, environment variables f
 Setting command for Intel Parallel Studio XE is following:
 
 ```
-[username@g0001 ~]$ module load intel/2020.4.304
+[username@g0001 ~]$ module load intel/2022.0.2
 ```
 
 List of compile/link commands of Intel Parallel Studio XE:
@@ -55,26 +55,6 @@ List of compile/link commands of PGI Compiler:
 | C | pgcc |
 | C++ | pgc++ |
 
-## NVIDIA HPC SDK
-
-NVIDIA HPC SDK is available on the ABCI System.
-To use NVIDIA HPC SDK, set up user environment by the `module` command.
-If you set up with the `module` command in compute node, environment variables for compilation and execution are set automatically.
-
-Setting command for NVIDIA HPC SDK is following:
-
-```
-[username@g0001 ~]$ module load nvhpc/21.2
-```
-
-List of compile/link commands of NVIDIA HPC SDK:
-
-| Programing Language | command |
-|:--|:--|
-| Fortran | nvfortran |
-| C | nvc |
-| C++ | nvc++ |
-
 ## OpenMP
 
 The compilers provided on the ABCI System support thread parallelization by OpenMP specifications.
@@ -85,7 +65,6 @@ To activate the OpenMP specifications, specify the compile option as follows:
 | GCC | -fopenmp |
 | Intel Parallel Studio | -qopenmp |
 | PGI | -mp |
-| NVIDIA HPC SDK | -mp |
 
 ## CUDA
 

--- a/en/docs/environment-modules.md
+++ b/en/docs/environment-modules.md
@@ -98,8 +98,8 @@ cuda/10.2/10.2.89(7):ERROR:150: Module 'cuda/10.2/10.2.89' conflicts with the cu
 ### Switch modules
 
 ```
-[username@g0001 ~]$ module load python/2.7/2.7.18
-[username@g0001 ~]$ module switch python/2.7/2.7.18 python/3.6/3.6.12
+[username@g0001 ~]$ module load cuda/10.2/10.2.89
+[username@g0001 ~]$ module switch cuda/10.2/10.2.89 cuda/11.0/11.0.3
 ```
 
 Switching may not be successful if there are dependencies.

--- a/en/docs/faq.md
+++ b/en/docs/faq.md
@@ -10,12 +10,6 @@ $ stty -ixon
 
 Executing while logged in to the interactive node has the same effect.
 
-## Q. The Group Area is consumed more than the actual size
-
-Generally, any file systems have their own block size, and even the smallest file consumes the capacity of the block size.
-
-ABCI sets the block size of the Group Area 1,2,3 to 128 KB and the block size of the home area and Group Area to 4 KB. For this reason, if a large number of small files are created in the Group Area 1,2,3 , usage efficiency will be reduced. For example, if you want to create a file that is less than 4KB in the Group Area, you need about 32 times the capacity of the home area.
-
 ## Q. Singularity cannot use container registries that require authentication
 
 SingularityPRO has a function equivalent to ``docker login`` that provides authentication information with environment variables.
@@ -31,32 +25,13 @@ For more information on SingularityPRO authentication, see below.
 * [SingularityPRO 3.7 User Guide](https://repo.sylabs.io/c/0f6898986ad0b646b5ce6deba21781ac62cb7e0a86a5153bbb31732ee6593f43/guides/singularitypro37-user-guide/)
     * [Making use of private images from Private Registries](https://repo.sylabs.io/c/0f6898986ad0b646b5ce6deba21781ac62cb7e0a86a5153bbb31732ee6593f43/guides/singularitypro37-user-guide/singularity_and_docker.html?highlight=support%20docker%20oci#making-use-of-private-images-from-private-registries)
 
-## Q. NGC CLI cannot be executed
-
-When running [NGC Catalog CLI](https://docs.nvidia.com/ngc/ngc-catalog-cli-user-guide/index.html) on ABCI, the following error message appears and execution is not possible. This is because the NGC CLI is built for Ubuntu 14.04 and later.
-
-```
-ImportError: /lib64/libc.so.6: version `GLIBC_2.18' not found (required by /tmp/_MEIxvHq8h/libstdc++.so.6)
-[89261] Failed to execute script ngc
-```
-
-By preparing the following shell script, it can be executed using Singularity. This technique can be used not only for NGC CLI but also for general use.
-
-```
-#!/bin/sh
-source /etc/profile.d/modules.sh
-module load singularitypro
-
-NGC_HOME=$HOME/ngc
-singularity exec $NGC_HOME/ubuntu-18.04.simg $NGC_HOME/ngc $@
-```
 
 ## Q. I want to assign multiple compute nodes and have each compute node perform different processing
 
 If you give `-l rt_F=N` or `-l rt_AF=N` option to `qrsh` or `qsub`, you can assign N compute nodes. You can also use MPI if you want to perform different processing on each assigned compute node.
 
 ```
-$ module load openmpi/2.1.6
+$ module load openmpi/4.1.3
 $ mpirun -hostfile $SGE_JOB_HOSTLIST -np 1 command1 : -np 1 command2 : ... : -np1 commandN
 ```
 
@@ -77,49 +52,6 @@ Host as.abci.ai
 
 !!! note
     The default value of ServerAliveInterval is 0 (no KeepAlive).
-
-## Q. I want to use a newer version of Open MPI
-
-ABCI offers CUDA-aware and CUDA non-aware versions of Open MPI, and you can check the availability provided by [Open MPI](mpi.md#open-mpi).
-
-The Environment Modules provided by ABCI will attempt to configure CUDA-aware Open MPI environment when loading `openmpi` module only if `cuda` module has been loaded beforehand.
-
-For the combination where CUDA-aware MPI is provided (`cuda/10.0/10.0.130.1`, `openmpi/2.1.6`), therefore, the environment settings will succeed:
-
-```
-$ module load cuda/10.0/10.0.130.1
-$ module load openmpi/2.1.6
-$ module list
-Currently Loaded Modulefiles:
-  1) cuda/10.0/10.0.130.1   2) openmpi/2.1.6
-```
-
-For the combination where CUDA-aware MPI is not provided (`cuda/9.1/9.1.85.3`, `openmpi/3.1.6`), the environment setup will fail and `openmpi` module will not be loaded:
-
-```
-$ module load cuda/9.1/9.1.85.3
-$ module load openmpi/3.1.6
-ERROR: loaded cuda module is not supported.
-WARNING: openmpi/3.1.6 cannot be loaded due to missing prereq.
-HINT: at least one of the following modules must be loaded first: cuda/9.2/9.2.88.1 cuda/9.2/9.2.148.1 cuda/10.0/10.0.130.1 cuda/10.1/10.1.243 cuda/10.2/10.2.89 cuda/11.0/11.0.3 cuda/11.1/11.1.1 cuda/11.2/11.2.2
-$ module list
-Currently Loaded Modulefiles:
-  1) cuda/9.1/9.1.85.3
-```
-
-On the other hand, there are cases where CUDA-aware version of Open MPI is not necessary, such as when you want to use Open MPI just for parallelization by Horovod. In this case, you can use a newer version of Open MPI that does not support CUDA-aware functions by loading `openmpi` module first.
-
-```
-$ module load openmpi/3.1.6
-$ module load cuda/9.1/9.1.85.3
-module list
-Currently Loaded Modulefiles:
-  1) openmpi/3.1.6       2) cuda/9.1/9.1.85.3
-```
-
-!!! note
-    The functions of CUDA-aware versions of Open MPI can be found on the Open MPI site:
-    [FAQ: Running CUDA-aware Open MPI](https://www.open-mpi.org/faq/?category=runcuda)
 
 ## Q. I want to know how ABCI job execution environment is congested
 

--- a/en/docs/tips/jupyter-notebook.md
+++ b/en/docs/tips/jupyter-notebook.md
@@ -9,24 +9,22 @@ This part explains how to install and use Jupyter Notebook with pip.
 ### Install by Pip
 
 First, you need to occupy one compute node, create a Python virtual environment, and install `tensorflow-gpu` and` jupyter` with `pip`.
+In this example, `tensorflow-gpu` and` jupyter` are installed into `~/jupyter_env` directory.
 
 ```
 [username@es1 ~]$ qrsh -g grpname -l rt_F=1 -l h_rt=1:00:00
-[username@g0001 ~]$ module load python/3.6/3.6.12 cuda/11.0/11.0.3 cudnn/8.1/8.1.1 gcc/7.4.0
+[username@g0001 ~]$ module load module load gcc/9.3.0 python/3.10 cuda/11.2 cudnn/8.1
 [username@g0001 ~]$ python3 -m venv ~/jupyter_env
 [username@g0001 ~]$ source ~/jupyter_env/bin/activate
-(jupyter_env) [username@g0001 ~]$ pip3 install tensorflow jupyter numpy
+(jupyter_env) [username@g0001 ~]$ python3 -m pip install --upgrade pip
+(jupyter_env) [username@g0001 ~]$ python3 -m pip install tensorflow jupyter numpy
 ```
-
-!!! note
-    In this example, `tensorflow-gpu` and` jupyter` are installed into `~/jupyter_env` directory.
-
 
 From the next time on, you only need to load modules and activate `~/jupyter_env` as shown below.
 
 ```
 [username@es1 ~]$ qrsh -g grpname -l rt_F=1 -l h_rt=1:00:00
-[username@g0001 ~]$ module load python/3.6/3.6.12 cuda/11.0/11.0.3 cudnn/8.1/8.1.1 gcc/7.4.0
+[username@g0001 ~]$ module load module load gcc/9.3.0 python/3.10 cuda/11.2 cudnn/8.1
 [username@g0001 ~]$ source ~/jupyter_env/bin/activate
 ```
 
@@ -82,10 +80,8 @@ To check the operation, when the dashboard screen of Jupyter Notebook is display
 ```
 import tensorflow
 print(tensorflow.__version__)
-print(tensorflow.test.is_gpu_available())
+print(tensorflow.config.list_physical_devices('GPU'))
 ```
-
-``is_gpu_available()`` also returns False if it cannot recognize the cuDNN library.
 
 For how to use Jupyter Notebook, please see the [Jupyter Notebook Documentation](https://jupyter-notebook.readthedocs.io/en/stable/examples/Notebook/Notebook%20Basics.html).
 
@@ -93,9 +89,9 @@ For how to use Jupyter Notebook, please see the [Jupyter Notebook Documentation]
 
 Jupyter Notebook will be terminated by the following steps:
 
-* (Local PC) Exit with the `Quit` button on the dashboard screen
-* (Local PC) Press `Control-C` and terminate SSH tunnel connection that was forwarding port 8888
-* (Compute Node) If `jupyter` program is not finished, quit with `Control-C`
+1. (Local PC) Exit with the `Quit` button on the dashboard screen
+2. (Local PC) Press `Control-C` and terminate SSH tunnel connection that was forwarding port 8888
+3. (Compute Node) If `jupyter` program is not finished, quit with `Control-C`
 
 ## Using Singularity
 
@@ -107,16 +103,15 @@ Get the container image. Here, the Docker image (``nvcr.io/nvidia/tensorflow:19.
 
 ```
 [username@es1 ~]$ module load singularitypro
-[username@es1 ~]$ singularity pull docker://nvcr.io/nvidia/tensorflow:19.07-py3
+[username@es1 ~]$ singularity pull docker://nvcr.io/nvidia/tensorflow:22.07-tf2-py3
 INFO:    Converting OCI blobs to SIF format
 INFO:    Starting build...
 Getting image source signatures
-Copying blob 5b7339215d1d done
+Copying blob a1d578e9bd9d done
 :
 (snip)
 :
 INFO:    Creating SIF file...
-INFO:    Build complete: tensorflow_19.07-py3.sif
 ```
 
 ### Start Jupyter Notebook
@@ -133,24 +128,24 @@ Next, start Jupyter Notebook in the container image as shown below:
 
 ```
 [username@g0001 ~]$ module load singularitypro
-[username@g0001 ~]$ singularity run --nv ./tensorflow_19.07-py3.sif jupyter notebook --ip=`hostname` --port=8888 --no-browser
+[username@g0001 ~]$ singularity run --nv ./tensorflow_22.07-tf2-py3.sif jupyter notebook --ip=`hostname` --port=8888 --no-browser
 
 
 ================
 == TensorFlow ==
 ================
 
-NVIDIA Release 19.07 (build 7332442)
-TensorFlow Version 1.14.0
+NVIDIA Release 22.07-tf2 (build 41650896)
+TensorFlow Version 2.9.1
 
-Container image Copyright (c) 2019, NVIDIA CORPORATION.  All rights reserved.
-Copyright 2017-2019 The TensorFlow Authors.  All rights reserved.
+Container image Copyright (c) 2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+Copyright 2017-2022 The TensorFlow Authors.  All rights reserved.
 
 :
 (snip)
 :
-[I 13:40:14.131 NotebookApp] Use Control-C to stop this server and shut down all kernels (twice to skip confirmation).
-[C 13:40:14.138 NotebookApp]
+[I 17:34:25.645 NotebookApp] Use Control-C to stop this server and shut down all kernels (twice to skip confirmation).
+[C 17:34:25.654 NotebookApp]
 
     To access the notebook, open this file in a browser:
         file:///home/username/.local/share/jupyter/runtime/nbserver-xxxxxx-open.html

--- a/en/docs/tips/ngc.md
+++ b/en/docs/tips/ngc.md
@@ -120,10 +120,10 @@ Next, check the available versions of Open MPI on the ABCI system.
 [username@es1 ~] $ module avail openmpi
 
 -------------------- /apps/modules/modulefiles/centos7/mpi ---------------------
-openmpi/2.1.6          openmpi/3.1.6          openmpi/4.0.5(default)
+openmpi/4.0.5          openmpi/4.1.3(default)
 ```
 
-``openmpi/4.0.5`` module seems to be suitable to run this image. In general, at least the major versions of both MPIs should be the same.
+``openmpi/4.1.3`` module seems to be suitable to run this image. In general, at least the major versions of both MPIs should be the same.
 
 ### Run a Singularity image with MPI {#run-a-singularity-image-with-mpi}
 
@@ -131,7 +131,7 @@ Start an interative job with two full-nodes, and load required environment modul
 
 ```
 [username@es1 ~]$ qrsh -g grpname -l rt_F=2 -l h_rt=1:00:00
-[username@g0001 ~]$ module load singularitypro openmpi/4.0.5
+[username@g0001 ~]$ module load singularitypro openmpi/4.1.3
 ```
 
 Each full-node has four GPUs, and you have eight GPUs in total.

--- a/en/docs/tips/spack.md
+++ b/en/docs/tips/spack.md
@@ -81,7 +81,7 @@ As it is a waste of disk space, we recommend to configure Spack to *refer to* so
 
 Software referred by Spack can be defined in the configuration file `$HOME/.spack/linux/packages.yaml`.
 ABCI provides a pre-configured `packages.yaml` which defines mappings of Spack package and software installed on ABCI.
-Copying this file to your environment lets Spack use installed CUDA, OpenMPI, MVAPICH, cmake and etc.
+Copying this file to your environment lets Spack use installed CUDA, OpenMPI, cmake and etc.
 
 Compute Node (V)
 
@@ -124,11 +124,6 @@ packages:
 After you copy this file, when you let Spack install CUDA version 10.2.89, it use `cuda/10.2/10.2.89` environment module, instead of installing another copy of CUDA.
 `buildable: false` defined under CUDA section prohibits Spack to install other versions of CUDA specified here.
 If you let Spack install versions of CUDA which are not supported by ABCI, remove this directive.
-
-Because of an interpretation bug of package dependencies in `packages.yaml` of the current Spack, CUDA-aware OpenMPI supported by ABCI can not be registered.
-Therefore, `packages.yaml` provided by ABCI is configured to register only non-CUDA-aware OpenMPI.
-Moreover, installing a CUDA-aware OpenMPI whose version is same as a version of a registered non-CUDA-aware OpenMPI will fail.
-To avoid the failure, you need to install a version which is not registered in `packages.yaml` or remove the corresponding version from `packages.yaml`.
 
 Please refer to [the official document](https://spack.readthedocs.io/en/latest/build_settings.html) for detail about `packages.yaml`.
 
@@ -351,9 +346,6 @@ Use `spack env list` to display the list of created Spack environments.
 
 ### CUDA-aware OpenMPI {#cuda-aware-openmpi}
 
-ABCI provides software modules of CUDA-aware OpenMPI, however, they do not support all the combinations of compilers, CUDA and OpenMPI versions ([Reference](https://docs.abci.ai/en/08/#open-mpi)).
-It is easy to use Spack to install unsupported versions of CUDA-aware OpenMPI.
-
 #### How to Install {#how-to-install}
 
 This is an example of installing OpenMPI 3.1.1 that uses CUDA 10.1.243.
@@ -370,7 +362,7 @@ openmpi@3.1.1  ${SPACK_ROOT}/opt/spack/linux-centos7-haswell/gcc-4.8.5/openmpi-3
 ```
 
 Line #1 installs CUDA version `10.1.243` so that Spack uses a CUDA provided by ABCI.
-Line #2 installs OpenMPI 3.1.1 as the same configuration with [this page](../appendix/installed-software.md#open-mpi).
+Line #2 installs OpenMPI 3.1.1 as the same configuration with [Configuration of Installed Software](../appendix/installed-software.md#open-mpi).
 Meanings of the installation options are as follows.
 
 - `+cuda`: Build with CUDA support
@@ -433,7 +425,6 @@ If you no more use the OpenMPI, you can uninstall it by specifying the version a
 
 ### CUDA-aware MVAPICH2 {#cuda-aware-mvapich2}
 
-MVAPICH2 modules provided by ABCI does not support CUDA.
 If you want to use CUDA-aware MVAPICH2, install by yourself referring to the documents below.
 
 You have to use a compute node to build CUDA-aware MVAPICH2.

--- a/ja/docs/containers.md
+++ b/ja/docs/containers.md
@@ -77,7 +77,7 @@ INFO:    Build complete: ubuntu.sif
 [username@es1 singularity]$
 ```
 
-なお、上記コマンドにおいてイメージファイル(ubuntu.sif)の出力先をグループ領域(/groups1, /groups2)にするとエラーが発生します。その場合、singularityコマンドを実行する前に以下のように`id`コマンドでイメージ出力先グループ領域の所有グループを確認の上、`newgrp`コマンドを実施いただくことで回避可能です。
+なお、上記コマンドにおいてイメージファイル(ubuntu.sif)の出力先をグループ領域にするとエラーが発生します。その場合、singularityコマンドを実行する前に以下のように`id`コマンドでイメージ出力先グループ領域の所有グループを確認の上、`newgrp`コマンドを実施いただくことで回避可能です。
 下記例の`gaa00000`の箇所がイメージ出力先グループ領域の所有グループとなります。
 
 ```
@@ -108,7 +108,7 @@ Singularityを利用する場合、ジョブ中に`singularity run`コマンド�
 #$-l rt_F=1
 #$-j y
 source /etc/profile.d/modules.sh
-module load singularitypro openmpi/3.1.6
+module load singularitypro openmpi/4.0.5
 
 mpiexec -n 4 singularity exec --nv ./caffe2.img \
     python sample.py
@@ -184,7 +184,7 @@ DockerfileをSingularity recipeファイルに変換することで、ABCIシス
 Singularity Pythonのインストール例）
 
 ```
-[username@es1 ~]$ module load python/3.6/3.6.12
+[username@es1 ~]$ module load gcc/9.3.0 python/3.10
 [username@es1 ~]$ python3 -m venv work
 [username@es1 ~]$ source work/bin/activate
 (work) [username@es1 ~]$ pip3 install spython
@@ -195,10 +195,9 @@ Singularity Pythonのインストール例）
 Dockerfileから変換しただけでは次の2点の問題が発生するため、それぞれの対処が必要となります。
 
 - WORKDIRにファイルがコピーされない => コピー先をWORKDIRの絶対パスに設定
-- pipにパスが通らない => %postセクションにDockerイメージの環境変数を引き継ぐ設定を追加
 
 ```
-[username@es1 ~]$ module load python/3.6/3.6.12
+[username@es1 ~]$ module load gcc/9.3.0 python/3.10
 [username@es1 ~]$ source work/bin/activate
 (work) [username@es1 ~]$ git clone https://github.com/NVIDIA/DeepLearningExamples
 (work) [username@es1 ~]$ cd DeepLearningExamples/PyTorch/Detection/SSD
@@ -206,37 +205,38 @@ Dockerfileから変換しただけでは次の2点の問題が発生するため
 (work) [username@es1 SSD]$ cp -p ssd.def ssd_org.def
 (work) [username@es1 SSD]$ vi ssd.def
 Bootstrap: docker
-From: nvcr.io/nvidia/pytorch:20.06-py3
+From: nvcr.io/nvidia/pytorch:21.05-py3
 Stage: spython-base
 
 %files
-requirements.txt /workspace                     <- コピー先を相対パス（.）から絶対パスに変更
-./setup.py /workspace                           <- コピー先を相対パス（.）から絶対パスに変更
-./csrc /workspace/csrc                          <- コピー先を相対パス（.）から絶対パスに変更
-. /workspace                                    <- コピー先を相対パス（.）から絶対パスに変更
+requirements.txt /workspace/ssd/  #<- WORKDIR以下にコピー
+. /workspace/ssd/                 #<- WORKDIR以下にコピー
 %post
-FROM_IMAGE_NAME=nvcr.io/nvidia/pytorch:20.06-py3
-. /.singularity.d/env/10-docker2singularity.sh  <- 追加
+FROM_IMAGE_NAME=nvcr.io/nvidia/pytorch:21.05-py3
 
 # Set working directory
-cd /workspace
+cd /workspace/ssd
 
-PYTHONPATH="${PYTHONPATH}:/workspace"
-
+# Install nv-cocoapi
+COCOAPI_VERSION=2.0+nv0.6.0
+export COCOAPI_TAG=$(echo ${COCOAPI_VERSION} | sed 's/^.*+n//') \
+&& pip install --no-cache-dir pybind11                             \
+&& pip install --no-cache-dir git+https://github.com/NVIDIA/cocoapi.git@${COCOAPI_TAG}#subdirectory=PythonAPI
+# Install dllogger
 pip install --no-cache-dir git+https://github.com/NVIDIA/dllogger.git#egg=dllogger
+
+# Install requirements
 pip install -r requirements.txt
 python3 -m pip install pycocotools==2.0.0
-
-# Copy SSD code
-pip install .
+mkdir models #<- main.py実行時に必要なため追加
 
 %environment
-export PYTHONPATH="${PYTHONPATH}:/workspace"
+export COCOAPI_VERSION=2.0+nv0.6.0
 %runscript
-cd /workspace
+cd /workspace/ssd
 exec /bin/bash "$@"
 %startscript
-cd /workspace
+cd /workspace/ssd
 exec /bin/bash "$@"
 ```
 

--- a/ja/docs/development-tools.md
+++ b/ja/docs/development-tools.md
@@ -25,7 +25,7 @@ ABCIシステムではIntel Parallel Studio XEが利用可能です。
 Intel Parallel Studio XEの環境設定:
 
 ```
-[username@g0001 ~]$ module load intel/2020.4.304
+[username@g0001 ~]$ module load intel/2022.0.2
 ```
 
 コンパイル/リンクコマンド一覧:
@@ -57,26 +57,6 @@ PGIの環境設定:
 | C | pgcc |
 | C++ | pgc++ |
 
-## NVIDIA HPC SDK
-
-ABCIシステムではNVIDIA HPC SDKが利用可能です。
-利用するためには事前に`module`コマンドを用いて利用環境を設定する必要があります。
-計算ノードで`module`コマンドを用いて利用環境を設定すると、コンパイル用環境変数にヘッダファイルおよびライブラリのサーチパスが自動で設定され、実行用環境変数も自動で設定されます。
-
-NVIDIA HPC SDKの環境設定:
-
-```
-[username@g0001 ~]$ module load nvhpc/21.2
-```
-
-コンパイル/リンクコマンド一覧:
-
-| 言語処理系 | コマンド |
-|:--|:--|
-| Fortran | nvfortran |
-| C | nvc |
-| C++ | nvc++ |
-
 ## OpenMP
 
 ABCIシステムで用意されているコンパイラは、OpenMPを用いたスレッド並列化機能が実装されています。
@@ -87,7 +67,6 @@ OpenMPを有効化する場合、コンパイル/リンク時に以下のよう�
 | GCC | -fopenmp |
 | Intel Parallel Studio | -qopenmp |
 | PGI | -mp |
-| NVIDIA HPC SDK | -mp |
 
 ## CUDA
 

--- a/ja/docs/environment-modules.md
+++ b/ja/docs/environment-modules.md
@@ -98,8 +98,8 @@ cuda/10.2/10.2.89(7):ERROR:150: Module 'cuda/10.2/10.2.89' conflicts with the cu
 ### モジュールの切り替え {#switch-modules}
 
 ```
-[username@g0001 ~]$ module load python/2.7/2.7.18
-[username@g0001 ~]$ module switch python/2.7/2.7.18 python/3.6/3.6.12
+[username@g0001 ~]$ module load cuda/10.2/10.2.89
+[username@g0001 ~]$ module switch cuda/10.2/10.2.89 cuda/11.0/11.0.3
 ```
 
 依存関係があると切り替えがうまくできない場合があります。

--- a/ja/docs/tips/jupyter-notebook.md
+++ b/ja/docs/tips/jupyter-notebook.md
@@ -9,23 +9,22 @@ Jupyter Notebookは、コードの記述とその結果の取得を、ブラウ�
 ### インストール {#install-by-pip}
 
 計算ノードを一台占有し、Python仮想環境を作成し、`pip`で`tensorflow`と`jupyter`をインストールします。
+この例では`~/jupyter_env`ディレクトリの中にインストールしています。
 
 ```
 [username@es1 ~]$ qrsh -g grpname -l rt_F=1 -l h_rt=1:00:00
-[username@g0001 ~]$ module load python/3.6/3.6.12 cuda/11.0/11.0.3 cudnn/8.1/8.1.1 gcc/7.4.0
+[username@g0001 ~]$ module load gcc/9.3.0 python/3.10 cuda/11.2 cudnn/8.1
 [username@g0001 ~]$ python3 -m venv ~/jupyter_env
 [username@g0001 ~]$ source ~/jupyter_env/bin/activate
-(jupyter_env) [username@g0001 ~]$ pip3 install tensorflow jupyter numpy
+(jupyter_env) [username@g0001 ~]$ python3 -m pip install --upgrade pip
+(jupyter_env) [username@g0001 ~]$ python3 -m pip install tensorflow jupyter numpy
 ```
-
-!!! note
-    この例では`~/jupyter_env`ディレクトリの中にインストールしています。
 
 次回以降は、以下のようにモジュールの読み込みと`~/jupyter_env`のアクティベートだけで済みます。
 
 ```
 [username@es1 ~]$ qrsh -g grpname -l rt_F=1 -l h_rt=1:00:00
-[username@g0001 ~]$ module load python/3.6/3.6.12 cuda/11.0/11.0.3 cudnn/8.1/8.1.1 gcc/7.4.0
+[username@g0001 ~]$ module load gcc/9.3.0 python/3.10 cuda/11.2 cudnn/8.1
 [username@g0001 ~]$ source ~/jupyter_env/bin/activate
 ```
 
@@ -81,10 +80,8 @@ http://127.0.0.1:8888/?token=token_string
 ```
 import tensorflow
 print(tensorflow.__version__)
-print(tensorflow.test.is_gpu_available())
+print(tensorflow.config.list_physical_devices('GPU'))
 ```
-
-``is_gpu_available()``は、cuDNNライブラリを認識できない場合もFalseを返します。
 
 Jupyter Notebookの使い方は、[Jupyter Notebook Documentation](https://jupyter-notebook.readthedocs.io/en/stable/examples/Notebook/Notebook%20Basics.html)を参照してください。
 
@@ -92,9 +89,9 @@ Jupyter Notebookの使い方は、[Jupyter Notebook Documentation](https://jupyt
 
 以下の手順で終了します。
 
-* (ローカルPC) ダッシュボード画面の`Quit`ボタンで終了
-* (ローカルPC) 8888番ポートを転送していたSSHトンネル接続を`Control-C`で終了
-* (計算ノード) `jupyter`プログラムが終了していない場合は、`Control-C`で終了
+1. (ローカルPC) ダッシュボード画面の`Quit`ボタンで終了する
+2. (ローカルPC) 8888番ポートを転送していたSSHトンネル接続を`Control-C`で終了する
+3. (計算ノード) `jupyter`プログラムが終了していない場合は、`Control-C`で終了する
 
 ## Singularityを用いた利用手順 {#using-singularity}
 
@@ -106,16 +103,15 @@ pipインストールの代わりに、Jupyter Notebookがインストールさ�
 
 ```
 [username@es1 ~]$ module load singularitypro
-[username@es1 ~]$ singularity pull docker://nvcr.io/nvidia/tensorflow:19.07-py3
+[username@es1 ~]$ singularity pull docker://nvcr.io/nvidia/tensorflow:22.07-tf2-py3
 INFO:    Converting OCI blobs to SIF format
 INFO:    Starting build...
 Getting image source signatures
-Copying blob 5b7339215d1d done
+Copying blob a1d578e9bd9d done
 :
 (snip)
 :
 INFO:    Creating SIF file...
-INFO:    Build complete: tensorflow_19.07-py3.sif
 ```
 
 ### Jupyter Notebookの起動 {#start-jupyter-notebook_1}
@@ -132,23 +128,23 @@ g0001.abci.local
 
 ```
 [username@g0001 ~]$ module load singularitypro
-[username@g0001 ~]$ singularity run --nv ./tensorflow_19.07-py3.sif jupyter notebook --ip=`hostname` --port=8888 --no-browser
-                                                                                                                          
+[username@g0001 ~]$ singularity run --nv ./tensorflow_22.07-tf2-py3.sif jupyter notebook --ip=`hostname` --port=8888 --no-browser
+
 ================
 == TensorFlow ==
 ================
 
-NVIDIA Release 19.07 (build 7332442)
-TensorFlow Version 1.14.0
+NVIDIA Release 22.07-tf2 (build 41650896)
+TensorFlow Version 2.9.1
 
-Container image Copyright (c) 2019, NVIDIA CORPORATION.  All rights reserved.
-Copyright 2017-2019 The TensorFlow Authors.  All rights reserved.
+Container image Copyright (c) 2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+Copyright 2017-2022 The TensorFlow Authors.  All rights reserved.
 
 :
 (snip)
 :
-[I 13:40:14.131 NotebookApp] Use Control-C to stop this server and shut down all kernels (twice to skip confirmation).
-[C 13:40:14.138 NotebookApp]
+[I 17:34:25.645 NotebookApp] Use Control-C to stop this server and shut down all kernels (twice to skip confirmation).
+[C 17:34:25.654 NotebookApp]
 
     To access the notebook, open this file in a browser:
         file:///home/username/.local/share/jupyter/runtime/nbserver-xxxxxx-open.html

--- a/ja/docs/tips/ngc.md
+++ b/ja/docs/tips/ngc.md
@@ -116,10 +116,10 @@ Report bugs to http://www.open-mpi.org/community/help/
 [username@es1 ~]$ module avail openmpi
 
 -------------------- /apps/modules/modulefiles/centos7/mpi ---------------------
-openmpi/2.1.6          openmpi/3.1.6          openmpi/4.0.5(default)
+openmpi/4.0.5          openmpi/4.1.3(default)
 ```
 
-``openmpi/4.0.5`` を使うのが適当のようです。少なくともメジャーバージョンが一致している必要があります。
+``openmpi/4.1.3``を使うのが適当のようです。少なくともメジャーバージョンが一致している必要があります。
 
 ### SingularityイメージのMPI実行 {#run-a-singularity-image-with-mpi}
 
@@ -127,7 +127,7 @@ openmpi/2.1.6          openmpi/3.1.6          openmpi/4.0.5(default)
 
 ```
 [username@es1 ~]$ qrsh -g grpname -l rt_F=2 -l h_rt=1:00:00
-[username@g0001 ~]$ module load singularitypro openmpi/4.0.5
+[username@g0001 ~]$ module load singularitypro openmpi/4.1.3
 ```
 
 1ノードあたり4基のGPUがあり、2ノード占有では計8基のGPUが使えることになります。この場合、8個のプロセスをノードあたり4個ずつ並列に起動し、サンプルプログラム tensorflow_mnist.py を実行します。
@@ -164,7 +164,7 @@ INFO:tensorflow:loss = 0.17852336, step = 40 (0.225 sec)
 #$ -cwd
 
 source /etc/profile.d/modules.sh
-module load singularitypro openmpi/4.0.5
+module load singularitypro openmpi/4.1.3
 wget https://raw.githubusercontent.com/horovod/horovod/v0.22.1/examples/tensorflow/tensorflow_mnist.py
 mpirun -np 8 -npernode 4 singularity run --nv tensorflow_21.06-tf1-py3.sif python tensorflow_mnist.py
 ```

--- a/ja/docs/tips/spack.md
+++ b/ja/docs/tips/spack.md
@@ -80,7 +80,7 @@ Spackはソフトウェアの依存関係を解決して、依存するソフト
 ディスクスペースの浪費となりますので、ABCIが提供するソフトウェアは、Spackから*参照する*ように設定することをお勧めします。
 
 Spackが参照するソフトウェアの設定は`$HOME/.spack/linux/packages.yaml`に定義します。
-ABCIで提供するCUDA、OpenMPI、MVAPICH、cmake等の設定を記載した設定ファイル(packages.yaml)をユーザ環境にコピーすることでABCIのソフトウェアを*参照する*ことができます。
+ABCIで提供するCUDA、OpenMPI、cmake等の設定を記載した設定ファイル(packages.yaml)をユーザ環境にコピーすることでABCIのソフトウェアを*参照する*ことができます。
 
 計算ノード(V)
 
@@ -123,11 +123,6 @@ packages:
 このファイルを設置すると、例えば、SpackでCUDAのバージョン10.2.89のインストールを実行すると、実際にはインストールはされずに、SpackがEnvironment Modulesの`cuda/10.2/10.2.89`を使用するようになります。
 CUDAセクションで`buildable: false`を指定することにより、Spackはここで指定しているバージョン以外のCUDAをインストールしなくなります。
 ABCIが提供していないバージョンのCUDAをSpackでインストールしたい場合は、この記述を削除してください。
-
-現在のSpackでは`packages.yaml`内の依存関係の解釈に不具合があるため、ABCIが提供するCUDA-aware OpenMPIを登録する事は出来ません。
-そのためABCIが提供する`packages.yaml`では、CUDA-awareではないOpenMPIのみを登録しています。
-また、登録されているCUDA-awareではないOpenMPIと同じバージョンのCUDA-aware OpenMPIをインストールしようとすると、エラーになります。
-エラーを回避するには、`packages.yaml`に登録されていないバージョンをインストールするか、`packages.yaml`から該当バージョンを削除してご利用ください。
 
 `packages.yaml`ファイルの設定の詳細は[公式ドキュメント](https://spack.readthedocs.io/en/latest/build_settings.html)を参照ください。
 
@@ -347,9 +342,6 @@ Spackにはソフトウェアパッケージを「環境」という単位でグ
 
 ### CUDA-aware OpenMPI {#cuda-aware-openmpi}
 
-ABCIでは、CUDA-aware OpenMPIをモジュールで提供していますが、全てのコンパイラ、CUDA、OpenMPIの組み合わせで提供しているわけではありません（[参考](https://docs.abci.ai/ja/08/#open-mpi)）。
-使用したい組み合わせがモジュール提供されていない場合は、Spackでインストールするのが簡単です。
-
 #### インストール方法 {#how-to-install}
 
 CUDA 10.1.243を使用するOpenMPI 3.1.1をインストールする場合の例です。
@@ -366,7 +358,7 @@ openmpi@3.1.1  ${SPACK_ROOT}/opt/spack/linux-centos7-haswell/gcc-4.8.5/openmpi-3
 ```
 
 1行目では、ABCIが提供するCUDAを使用するよう、CUDAのバージョン`10.1.243`をインストールします。
-2行目では、[このページ](../appendix/installed-software.md#open-mpi)と同様の設定で、OpenMPIをインストールしています。
+2行目では、[インストール済みソフトウェアの構成](../appendix/installed-software.md#open-mpi)と同様の設定で、OpenMPIをインストールしています。
 インストールオプションの意味は以下の通りです。
 
 - `+cuda`: CUDAを有効にしてビルドします。
@@ -430,18 +422,17 @@ mpiexec ${MPIOPTS} YOUR_PROGRAM
 
 ### CUDA-aware MVAPICH2 {#cuda-aware-mvapich2}
 
-ABCIが提供するMVAPICH2モジュールはCUDA対応していません。
 CUDA-aware MVAPICH2を使用する場合は、以下を参考にSpackでインストールしてください。
 
 GPUを搭載する計算ノード上で作業を行います。
-[OpenMPIと同様](#cuda-aware-openmpi)に、使用するCUDAをインストールしたのちに、CUDAオプション（`+cuda`）、通信ライブラリ（`fabrics=mrail`）、およびCUDAの依存関係（`^cuda@10.1.243`）を指定してMVAPICH2をインストールします。
+上述した[CUDA-aware OpenMPI](#cuda-aware-openmpi)と同様に、使用するCUDAをインストールしたのちに、CUDAオプション（`+cuda`）、通信ライブラリ（`fabrics=mrail`）、およびCUDAの依存関係（`^cuda@10.1.243`）を指定してMVAPICH2をインストールします。
 
 ```Console
 [username@g0001 ~]$ spack install cuda@10.1.243
 [username@g0001 ~]$ spack install mvapich2@2.3.2 +cuda fabrics=mrail ^cuda@10.1.243
 ```
 
-使い方もOpenMPIと同様に、インストールしたMVAPICH2をロードして使います。
+使い方もCUDA-aware OpenMPIと同様に、インストールしたMVAPICH2をロードして使います。
 以下にジョブスクリプト例を示します。
 
 ```shell


### PR DESCRIPTION
提供を終了している機能、モジュールを使用している文章を修正しました。

faq.md中以下のエントリは内容が古いため削除しました。

* `Q. グループ領域が実サイズ以上に消費されてしまう`
    * ブロックサイズは現状4KBで統一されており、この問題は発生しない。
* `Q. NGC CLIが実行できない`
    * NGC CLIの最新(3.4.1)版ではエラーが発生しないことを確認した。
* `Q. Open MPIの新しいバージョンが使いたい`
    * CUDA-aware OpenMPIは現在提供していない。

38ed8c1
* Intel Parallel Studio XEのモジュール名を更新しました。
* NVIDIA HPC SDKは提供していないため、「開発ツール」のページから削除しました。